### PR TITLE
docs: update github contributors link

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -14,7 +14,7 @@ To keep up to date on all things Apollo, you can follow us on [Twitter](https://
 
 ### Contribute to Apollo
 
-The Apollo project lives on [GitHub](https://github.com/apollographql), and is made up of a diverse set of tools for implementing GraphQL, written and maintained by [contributors](https://github.com/orgs/apollostack/people) around the world. We’d love your help!
+The Apollo project lives on [GitHub](https://github.com/apollographql), and is made up of a diverse set of tools for implementing GraphQL, written and maintained by [contributors](https://github.com/orgs/apollographql/people) around the world. We’d love your help!
 
 Here are some ways you can get involved with the project:
 


### PR DESCRIPTION
I noticed that the main link to the github org has been updated in this repo but it's still pointing to the old github org in the actual Apollo site (http://dev.apollodata.com/community/). Perhaps the docs in production need to be redeployed?