### PR TITLE
docs: Add `hexo-prism-plus` to enable Prism syntax highlighting.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -373,6 +373,18 @@
         "readdirp": "2.1.0"
       }
     },
+    "clipboard": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
+      "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "good-listener": "1.2.2",
+        "select": "1.1.2",
+        "tiny-emitter": "2.0.2"
+      }
+    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -558,6 +570,13 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true,
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -1726,6 +1745,16 @@
         "is-glob": "2.0.1"
       }
     },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "delegate": "3.2.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -1934,6 +1963,18 @@
       "requires": {
         "chalk": "1.1.3",
         "hexo-bunyan": "1.0.0"
+      }
+    },
+    "hexo-prism-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexo-prism-plus/-/hexo-prism-plus-1.0.0.tgz",
+      "integrity": "sha512-OqJp3tp41VZAtpt0L7SqFk4GDMEIkSBQr8i45XURNLTIxEMvaXNzFgtjkB+5+wnFvZuJIpORzd8kdA2KiyHLVg==",
+      "dev": true,
+      "requires": {
+        "hexo-fs": "0.2.2",
+        "hexo-util": "0.6.3",
+        "lodash": "4.17.5",
+        "node-prismjs": "0.1.1"
       }
     },
     "hexo-renderer-ejs": {
@@ -3059,6 +3100,15 @@
       "integrity": "sha1-Mcur63GmeufdWn3AQuUcPHWGhQE=",
       "dev": true
     },
+    "node-prismjs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/node-prismjs/-/node-prismjs-0.1.1.tgz",
+      "integrity": "sha512-7TrcjtiF9XFemrdZ9sMliEkOx4IzRWspZGu938YF+9crjfxwaLhlbRpY9ulvxfVJr6ZrEuZ/HvN/uz5LJvSafQ==",
+      "dev": true,
+      "requires": {
+        "prismjs": "1.6.0"
+      }
+    },
     "nopt": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
@@ -3258,6 +3308,15 @@
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
+    "prismjs": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.6.0.tgz",
+      "integrity": "sha1-EY2V+3pm26InLjQ7NF9SNmWds2U=",
+      "dev": true,
+      "requires": {
+        "clipboard": "1.7.1"
+      }
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -3291,7 +3350,8 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "randomatic": {
       "version": "1.1.7",
@@ -3472,6 +3532,13 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz",
       "integrity": "sha1-gaCY9Efku8P/MxKiQ1IbwGDvWRE=",
+      "dev": true,
+      "optional": true
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
       "dev": true,
       "optional": true
     },
@@ -3663,6 +3730,13 @@
         "os-homedir": "1.0.2"
       }
     },
+    "tiny-emitter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
+      "dev": true,
+      "optional": true
+    },
     "titlecase": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/titlecase/-/titlecase-1.1.2.tgz",
@@ -3674,6 +3748,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "punycode": "1.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "apollo-hexo-config": "1.0.6",
     "chexo": "1.0.4",
     "hexo": "3.7.0",
+    "hexo-prism-plus": "^1.0.0",
     "hexo-renderer-ejs": "0.3.1",
     "hexo-renderer-less": "0.2.0",
     "hexo-renderer-marked": "0.3.2",


### PR DESCRIPTION
The default syntax highlighting provided by Hexo uses highlight.js.  While there are a number of great syntax highlights provided by highlight.js, some of the more important ones to the Apollo project: `graphql`, `typescript`, and `jsx` are notably missing.

This uses the `hexo-prism-plus` plugin for Hexo, along with some upstream configuration to `apollo-hexo-config`[0] and `meteor-theme-hexo` (previously named `hexo-theme-meteor`)[1].  See refs for more information!

**The Netlify preview for this PR should be checked prior to merging!**

:crossed_fingers:

[0] https://github.com/apollographql/apollo-hexo-config/commit/547107b0
[1] https://github.com/meteor/meteor-theme-hexo/pull/61