### PR TITLE
Remove link to Spectrum

### DIFF
--- a/source/index.mdx
+++ b/source/index.mdx
@@ -8,7 +8,7 @@ In this section, you can learn how to get help with Apollo and GraphQL, contribu
 
 ## Join the Community
 
-Come chat with Apollo team members, contributors, and developers on [Spectrum](https://spectrum.chat/apollo). It’s a great place to get help using Apollo and discuss the latest in the GraphQL community.
+Come chat with Apollo team members, contributors, and developers on [our community portal](https://community.apollographql.com/). It’s a great place to get help using Apollo and discuss the latest in the GraphQL community.
 
 To keep up to date on all things Apollo, you can follow us on [Twitter](https://twitter.com/apollographql), [Medium](https://medium.com/apollo-stack), and [Facebook](https://www.facebook.com/apollographql/).
 


### PR DESCRIPTION
Hi, I noticed that you have your own community portal now, this will save users an extra jump which is mildly frustrating!

**Pull Request Label:**

- [ ] feature
- [ ] blocking
- [X] docs

