### PR TITLE
Jay/add events link

### DIFF
--- a/source/graphql-events.md
+++ b/source/graphql-events.md
@@ -5,6 +5,10 @@ description: ''
 
 The team at Apollo loves to speak at events, help community members looking to speak about GraphQL or Apollo, and organize quality events. Read on to see how you can get involved!
 
+## Apollo GraphQL Events
+
+Head over to [Apollo GraphQL's events hub](https://apollographql.com/events/) to register for our upcoming events, or watch any of our past events on-demand.
+
 ## Give a talk
 
 Whether you're gearing up to give a GraphQL or Apollo talk at a local meetup or a large industry event, we want to help spread the word and set you up with the resources to feel prepared. [Let us know on Twitter](https://twitter.com/apollographql) about events you're submitting to, when you're planning to speak, or when your talk videos have been published!

--- a/source/graphql-events.md
+++ b/source/graphql-events.md
@@ -5,9 +5,9 @@ description: ''
 
 The team at Apollo loves to speak at events, help community members looking to speak about GraphQL or Apollo, and organize quality events. Read on to see how you can get involved!
 
-## Apollo GraphQL Events
+## Bookmark our events hub
 
-Head over to [Apollo GraphQL's events hub](https://apollographql.com/events/) to register for our upcoming events, or watch any of our past events on-demand.
+[Apollo events](https://apollographql.com/events/) is where you can find all of our upcoming events and webinars as well as any recordings from our past events. If you want to keep up to date on GraphQL best practices, Apollo open source updates, new product features, and more, make sure to check the events regularly! 
 
 ## Give a talk
 

--- a/source/index.mdx
+++ b/source/index.mdx
@@ -2,9 +2,7 @@
 title: Get Involved
 description: ''
 ---
-Welcome! The Apollo community is made up of developers around the world who are building awesome things with GraphQL. The project is sponsored by [Meteor Development Group](http://www.meteor.com), where many of Apollo’s core contributors work.
-
-In this section, you can learn how to get help with Apollo and GraphQL, contribute to Apollo projects, and attend events and talks organized by the community.
+Welcome! The Apollo community is made up of developers around the world who are building awesome things with GraphQL. In this section, you can learn how to get help with Apollo and GraphQL, contribute to Apollo projects, and attend events and talks organized by the community.
 
 ## Join the Community
 


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

This PR removes a reference to Meteor on the Community page & adds a link to ApolloGraphQL.com/events on the GrapQL Events page.